### PR TITLE
Updated doc for `assoc`

### DIFF
--- a/src/clj/clojure/core.clj
+++ b/src/clj/clojure/core.clj
@@ -182,8 +182,9 @@
  ^{:arglists '([map key val] [map key val & kvs])
    :doc "assoc[iate]. When applied to a map, returns a new map of the
     same (hashed/sorted) type, that contains the mapping of key(s) to
-    val(s). When applied to a vector, returns a new vector that
-    contains val at index. Note - index must be <= (count vector)."
+    val(s). If map is nil, returns a new map of key(s) to val(s). When 
+    applied to a vector, returns a new vector that contains val at index. 
+    Note - index must be <= (count vector)."
    :added "1.0"
    :static true}
  assoc


### PR DESCRIPTION
`assoc` will return the map `{key val}` even if the `map` argument is nil. It was not clear from the doc string that this was the case. Updated the doc string to reflect this behavior.
